### PR TITLE
Added security level mutator methods.

### DIFF
--- a/shim.c
+++ b/shim.c
@@ -405,6 +405,14 @@ void X_OPENSSL_free(void *ref) {
 	OPENSSL_free(ref);
 }
 
+void X_SSL_set_security_level(SSL *ssl, int level) {
+ SSL_set_security_level(ssl, level);
+}
+
+int X_SSL_get_security_level(SSL *ssl) {
+ return SSL_get_security_level(ssl);
+}
+
 long X_SSL_set_options(SSL* ssl, long options) {
 	return SSL_set_options(ssl, options);
 }

--- a/shim.h
+++ b/shim.h
@@ -45,6 +45,8 @@ extern void X_OPENSSL_free(void *ref);
 extern void *X_OPENSSL_malloc(size_t size);
 
 /* SSL methods */
+extern void X_SSL_set_security_level(SSL *ssl, int level);
+extern int X_SSL_get_security_level(SSL *ssl);
 extern long X_SSL_set_options(SSL* ssl, long options);
 extern long X_SSL_get_options(SSL* ssl);
 extern long X_SSL_clear_options(SSL* ssl, long options);

--- a/ssl.go
+++ b/ssl.go
@@ -72,6 +72,18 @@ func (s *SSL) GetServername() string {
 	return C.GoString(C.SSL_get_servername(s.ssl, C.TLSEXT_NAMETYPE_host_name))
 }
 
+// GetSecurityLevel gets the SSL security level. See
+// https://www.openssl.org/docs/ssl/SSL_get_security_level.html
+func (s *SSL) GetSecurityLevel() int {
+	return int(C.X_SSL_get_security_level(s.ssl))
+}
+
+// SetSecurityLevel sets the SSL security level. See
+// https://www.openssl.org/docs/ssl/SSL_set_security_level.html
+func (s *SSL) SetSecurityLevel(level int) {
+	C.X_SSL_set_security_level(s.ssl, C.int(level))
+}
+
 // GetOptions returns SSL options. See
 // https://www.openssl.org/docs/ssl/SSL_CTX_set_options.html
 func (s *SSL) GetOptions() Options {


### PR DESCRIPTION
New funcs:

* GetSecurityLevel() int
  * mapped to SSL_get_security_level
  * https://www.openssl.org/docs/ssl/SSL_get_security_level.html

* SetSecurityLevel(level int)
  * mapped to SSL_set_security_level
  * https://www.openssl.org/docs/ssl/SSL_set_security_level.html

Signed-off-by: Peter Grzybowski <peter@northern.tech>